### PR TITLE
Added use of compression to indexer and xarray wrapper

### DIFF
--- a/kerchunk_tools/xarray_wrapper.py
+++ b/kerchunk_tools/xarray_wrapper.py
@@ -3,20 +3,25 @@ import xarray as xr
 import fsspec
 import s3fs
 
+_xr_open_args = {"consolidated": False}
 
-def wrap_xr_open(file_uri, scheme="posix", s3_config=None):
+
+def wrap_xr_open(file_uri, scheme="posix", s3_config=None, compression="infer"):
+    if compression == "infer":
+        compression = "zstd" if file_uri.split(".")[-1].lower() == "zstd" else None
+
     if scheme == "s3" or s3_config:
-        return _open_as_s3(file_uri, s3_config)
+        return _open_as_s3(file_uri, s3_config, compression=compression)
     else:
-        return _open_as_posix(file_uri)
+        return _open_as_posix(file_uri, compression=compression)
 
 
-def _open_as_posix(file_uri):
-    mapper = fsspec.get_mapper("reference://", fo=file_uri)
-    return xr.open_zarr(mapper) 
+def _open_as_posix(file_uri, compression=None):
+    mapper = fsspec.get_mapper("reference://", fo=file_uri, target_options={"compression": compression})
+    return xr.open_zarr(mapper, **_xr_open_args)
 
 
-def _open_as_s3(file_uri, s3_config):
+def _open_as_s3(file_uri, s3_config, compression=None):
     # construct the input options for fsspec
     fssopts = {
                 "key": s3_config["token"],
@@ -26,6 +31,7 @@ def _open_as_s3(file_uri, s3_config):
 
     ref = s3fs.S3FileSystem(**fssopts).open(file_uri)
     mapper = fsspec.get_mapper("reference://", fo=ref, target_protocol="http", 
-                               remote_options=fssopts)
-    return xr.open_zarr(mapper)
+                               remote_options=fssopts, target_options={"compression": compression})
+    return xr.open_zarr(mapper, **_xr_open_args)
+
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ numpy
 requests
 s3fs
 xarray
+zstd


### PR DESCRIPTION
Following discussion on the kerchunk issue list - it turns out that templating will be deprecated in favour of fast `zstd` compression. I have added hooks to incorporate those features to the Indexer and Xarray wrapper code.

Next up, we will need to add it to the command-line.

Note, my test code for this was - we need to add formal unit testing (with `mini-esgf-data`):

```
from kerchunk_tools.indexer import Indexer as IX
from kerchunk_tools import xarray_wrapper as xw

file_list_file = "file-list.txt"
file_uris = open(file_list_file).read().strip().split()
jkc = "index.json"
zkc = "index.zstd"

x = IX()
x.create(file_uris, prefix="test1", output_path=jkc, compression=None, max_bytes=-1)
x.create(file_uris, prefix="test1", output_path=zkc, compression="zstd", max_bytes=-1)

tzkc = f"test1/{zkc}"
tjkc = f"test1/{jkc}"

ds1 = xw.wrap_xr_open(tzkc, compression="zstd")
ds2 = xw.wrap_xr_open(tzkc, compression="infer")
ds3 = xw.wrap_xr_open(tjkc)
ds4 = xw.wrap_xr_open(tjkc, compression=None)

print(ds1)
print(ds2)

for n, ds in enumerate([ds2, ds3, ds4]):
    print("Comparing", n + 1)
    assert ds1.equals(ds)
```